### PR TITLE
Remove references to CrawlerManager.path

### DIFF
--- a/memorious/logic/manager.py
+++ b/memorious/logic/manager.py
@@ -26,7 +26,7 @@ class CrawlerManager(object):
                 self.crawlers[crawler.name] = crawler
 
     def run_scheduled(self):
-        log.info('%s crawlers found in [%s]' % (len(self.crawlers), self.path))
+        log.info('%s crawlers found' % len(self.crawlers))
         for crawler in self:
             if crawler.delta is None:
                 log.info('[%s] has no schedule.', crawler.name)
@@ -38,7 +38,7 @@ class CrawlerManager(object):
                 log.info('[%s] not due.', crawler.name)
 
     def run_cleanup(self):
-        log.info('%s crawlers found in [%s]' % (len(self.crawlers), self.path))
+        log.info('%s crawlers found' % len(self.crawlers))
         for crawler in self:
             crawler.cleanup()
 


### PR DESCRIPTION
CrawlerManager no longer has a single path since
adc4bbbbd36fc0823752754d5df3098453cc76e6, so left-over
references to CrawlerManager.path cause errors