### PR TITLE
Fix/example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ docs/_templates
 memorious/tests/testdata/data/*
 .tox
 .pytest_cache/*
+.idea/

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -13,7 +13,7 @@ services:
 
   ui:
     build: .
-    command: gunicorn -t 900 -w 8 -b 0.0.0.0:8000 --log-level info --log-file - memorious_ui:app 
+    command: gunicorn -t 900 -w 8 -b 0.0.0.0:8000 --log-level info --log-file - memorious.ui:app
     links:
       - redis
     volumes:


### PR DESCRIPTION
The docker-compose file was (still) referring to a non-existent ui module. A simple rename suffices. This fixes #50