### PR TITLE
FIX guess file extension from MIME type

### DIFF
--- a/memorious/operations/store.py
+++ b/memorious/operations/store.py
@@ -33,13 +33,14 @@ def directory(context, data):
 
         path = _get_directory_path(context)
         file_name = data.get('file_name', result.file_name)
+        dft_name = 'raw'
         if file_name is None:
             # try to guess at least the file extension ;
             # if no extension can be guessed, file_name will
-            # still be None
+            # still be None and dft_name still 'raw'
             mime_type = data['headers']['Content-Type']
-            file_name = mimetypes.guess_extension(mime_type)
-        file_name = safe_filename(file_name, default='raw')
+            dft_name = mimetypes.guess_extension(mime_type)
+        file_name = safe_filename(file_name, default=dft_name)
         file_name = '%s.%s' % (content_hash, file_name)
         data['_file_name'] = file_name
         file_path = os.path.join(path, file_name)

--- a/memorious/operations/store.py
+++ b/memorious/operations/store.py
@@ -1,3 +1,4 @@
+import mimetypes
 import os
 import json
 import shutil
@@ -32,6 +33,12 @@ def directory(context, data):
 
         path = _get_directory_path(context)
         file_name = data.get('file_name', result.file_name)
+        if file_name is None:
+            # try to guess at least the file extension ;
+            # if no extension can be guessed, file_name will
+            # still be None
+            mime_type = data['headers']['Content-Type']
+            file_name = mimetypes.guess_extension(mime_type)
         file_name = safe_filename(file_name, default='raw')
         file_name = '%s.%s' % (content_hash, file_name)
         data['_file_name'] = file_name


### PR DESCRIPTION
This PR changes the behavior of `store.directory` so that, when `file_name` is None, the saved file has at least the right file extension instead of 'raw'.
The file extension is guessed from the MIME type using the `mimetypes` module, as suggested by @pudo .