### PR TITLE
ENH parse uses xpath() instead of findall()

### DIFF
--- a/memorious/operations/parse.py
+++ b/memorious/operations/parse.py
@@ -29,12 +29,12 @@ def parse_html(context, data, result):
     else:
         roots = []
         for path in include:
-            roots = roots + result.html.findall(path)
+            roots = roots + result.html.xpath(path)
 
     seen = set()
     for root in roots:
         for tag_query, attr_name in URL_TAGS:
-            for element in root.findall(tag_query):
+            for element in root.xpath(tag_query):
                 attr = element.get(attr_name)
                 if attr is None:
                     continue


### PR DESCRIPTION
This PR changes the implementation of the `parse` operation, so `xpath()` is called instead of `findall()` for `include_paths`.
Paths in `include_paths` can now use the entire XPath language instead of the restricted subset inherited from the `ElementTree` API (see https://lxml.de/3.0/FAQ.html#what-are-the-findall-and-xpath-methods-on-element-tree).
Note that `{namespace}tagname` notations are not supported anymore.