### PR TITLE
FIX res is not an attr of MimeTypeRule

### DIFF
--- a/memorious/helpers/rule.py
+++ b/memorious/helpers/rule.py
@@ -90,7 +90,7 @@ class MimeTypeRule(Rule):
         self.clean = normalize_mimetype(self.value)
 
     def apply(self, res):
-        return self.res.content_type == self.clean
+        return res.content_type == self.clean
 
 
 class MimeGroupRule(Rule):


### PR DESCRIPTION
This PR fixes `MimeTypeRule.apply()` that was broken : `res` is not an attribute of a Rule.