### PR TITLE
FIX store mimetype

### DIFF
--- a/memorious/operations/store.py
+++ b/memorious/operations/store.py
@@ -50,9 +50,6 @@ def directory(context, data):
 
         path = _get_directory_path(context)
         file_name = data.get('file_name', result.file_name)
-        # the MIME type (aka 'Media-Type') is the first part of 'Content-Type'
-        # if we keep the eventual charset or boundary, guess_extension()
-        # returns None
         mime_type = normalize_mimetype(data.get('headers', {}).get('Content-Type'))
         extension = _get_file_extension(file_name, mime_type)
         file_name = file_name or 'data'

--- a/memorious/operations/store.py
+++ b/memorious/operations/store.py
@@ -28,7 +28,7 @@ def _get_file_extension(file_name, mime_type):
             return extension
     if mime_type is not None:
         extension = mimetypes.guess_extension(mime_type)
-        if extension is not None:    
+        if extension is not None:
             extension = extension.replace('.', '')
             if len(extension) > 1:
                 return extension
@@ -48,7 +48,10 @@ def directory(context, data):
 
         path = _get_directory_path(context)
         file_name = data.get('file_name', result.file_name)
-        mime_type = data.get('headers', {}).get('Content-Type')
+        # the MIME type (aka 'Media-Type') is the first part of 'Content-Type'
+        # if we keep the eventual charset or boundary, guess_extension()
+        # returns None
+        mime_type = data.get('headers', {}).get('Content-Type').split(';')[0]
         extension = _get_file_extension(file_name, mime_type)
         file_name = file_name or 'data'
         file_name = safe_filename(file_name, extension=extension)

--- a/memorious/operations/store.py
+++ b/memorious/operations/store.py
@@ -2,7 +2,9 @@ import mimetypes
 import os
 import json
 import shutil
+
 from normality import safe_filename
+from pantomime import normalize_mimetype
 
 from memorious import settings
 
@@ -51,7 +53,7 @@ def directory(context, data):
         # the MIME type (aka 'Media-Type') is the first part of 'Content-Type'
         # if we keep the eventual charset or boundary, guess_extension()
         # returns None
-        mime_type = data.get('headers', {}).get('Content-Type').split(';')[0]
+        mime_type = normalize_mimetype(data.get('headers', {}).get('Content-Type'))
         extension = _get_file_extension(file_name, mime_type)
         file_name = file_name or 'data'
         file_name = safe_filename(file_name, extension=extension)


### PR DESCRIPTION
This PR extracts the MIME type from the (possibly longer) Content-Type.
Extra elements (eg. charset) cause `mimetypes.guess_extension()` to return `None`, so we drop them.