### PR TITLE
FIX normalize_url optional everywhere

### DIFF
--- a/memorious/logic/http.py
+++ b/memorious/logic/http.py
@@ -205,7 +205,10 @@ class ContextHttpResponse(object):
         if self._url is not None:
             return self._url
         if self._response is not None:
-            return normalize_url(self._response.url)
+            if self.context.params.get('normalize_url', True):
+                return normalize_url(self._response.url)
+            else:
+                return self._response.url
         if self.request is not None:
             return self.request.url
 

--- a/memorious/operations/parse.py
+++ b/memorious/operations/parse.py
@@ -40,7 +40,9 @@ def parse_html(context, data, result):
                     continue
 
                 try:
-                    url = normalize_url(urljoin(result.url, attr))
+                    url = urljoin(result.url, attr)
+                    if context.params.get('normalize_url', True):
+                        url = normalize_url(url)
                 except Exception:
                     log.warning('Invalid URL: %r', attr)
                     continue


### PR DESCRIPTION
This PR makes `normalize_url` truly optional to solve issue #87 .

Concretely, the `parse` operation now accepts a param `normalize_url: False` that disables the normalization of the URLs parsed in a webpage.
The second change is that the `normalize_url` param for `fetch` now affects, in addition to the request URL, the response URL (via `memorious.logic.http.ContextHttpResponse`).