### PR TITLE
FIX load_session, login in quote_scraper

### DIFF
--- a/example/src/example/quotes.py
+++ b/example/src/example/quotes.py
@@ -22,6 +22,9 @@ def login(context, data):
         'username': username,
         'password': password
     }
+    # We also need to pass the hidden inputs from the form.
+    hidden_inputs = {h_in.get('name'): h_in.get('value') for h_in in form.xpath('./input[@type="hidden"]')}
+    login_data.update(hidden_inputs)
     context.http.post(login_url, data=login_data)
 
     # Set data for input to the next stage, and proceed.

--- a/memorious/logic/http.py
+++ b/memorious/logic/http.py
@@ -74,7 +74,7 @@ class ContextHttp(object):
         if self.STATE_SESSION not in self.context.state:
             return
         key = self.context.state.get(self.STATE_SESSION)
-        value = conn.get(make_key(self.context.run_id, "session", key))
+        value = conn.get(key)
         if value is not None:
             session = codecs.decode(bytes(value, 'utf-8'), 'base64')
             return pickle.loads(session)


### PR DESCRIPTION
This PR fixes session loading and the "extended_web_scraper" (quotes) example.

Session loading was broken because:
* At a given stage, `ContextHttp.save()` computes a global key `{run_id}:session:{key}` by passing a local key to `make_key()` ;
* At the following stage, `ContextHttp.load_session()` retrieves the global key from the previous stage but processes it as if it were a local key and calls `make_key` on it again.
The resulting weird global key does not exist, hence the session is not loaded and a new one is created.

Concretely, it means that any successful authentication in the `login` step in a crawler persists but cannot be retrieved by the following steps (the session and its cookies are never found because the key used to load the session is wrong).

This bug was silently affecting the "quotes" example aka `extended_web_scraper`.
In addition, authentication was not successful in the first place because the POST request sent by `quotes:login` was missing a hidden input from the login form.
The website is crawled and scraped but the scraped pages don't have the "(Goodreads page)" links that only appear if you're logged in.