### PR TITLE
ENH metadata can be defined on attribute values

### DIFF
--- a/memorious/operations/clean.py
+++ b/memorious/operations/clean.py
@@ -17,7 +17,7 @@ def clean_html(context, data):
 
     remove_paths = context.params.get('remove_paths')
     for path in ensure_list(remove_paths):
-        for el in doc.findall(path):
+        for el in doc.xpath(path):
             el.drop_tree()
 
     html_text = html.tostring(doc, pretty_print=True)

--- a/memorious/operations/parse.py
+++ b/memorious/operations/parse.py
@@ -77,7 +77,11 @@ def parse_for_metadata(context, data, html):
             element = html.xpath(xpath)[0]
             if element is None:
                 continue
-            value = collapse_spaces(element.text_content())
+            try:
+                value = collapse_spaces(element.text_content())
+            except AttributeError:
+                # useful when element is an attribute
+                value = collapse_spaces(str(element))
             if key in meta_date:
                 value = iso_date(value)
             if value is not None:

--- a/memorious/operations/parse.py
+++ b/memorious/operations/parse.py
@@ -18,7 +18,7 @@ URL_TAGS = [('.//a', 'href'),
 def parse_html(context, data, result):
     context.log.info('Parse: %r', result.url)
 
-    title = result.html.findtext('.//title')
+    title = result.html.xpath('.//title/text()')[0]
     if title is not None and 'title' not in data:
         data['title'] = title
 
@@ -74,7 +74,7 @@ def parse_for_metadata(context, data, html):
 
     for key, xpaths in meta_paths.items():
         for xpath in ensure_list(xpaths):
-            element = html.find(xpath)
+            element = html.xpath(xpath)[0]
             if element is None:
                 continue
             value = collapse_spaces(element.text_content())


### PR DESCRIPTION
This PR enables to define metadata whose value is parsed from attribute values.

I needed to replace `find()` with `xpath()` because attribute selection requires the full XPath specification and not the subset supported by the ElementTree API (https://lxml.de/3.0/FAQ.html#what-are-the-findall-and-xpath-methods-on-element-tree).
To be consistent I also replaced occurrences of `findall()`and `findtext()` in `parse` and `clean`.

One can now define, in the YAML config file, a metadata field named `source` whose value is defined as that of the attribute `src` of an `img` :
```yaml
name: test
description: test
# schedule: weekly
pipeline:
  init:
    [...]
  parse:
    method: parse
    params:
      [...]
      meta:
        source: './/div[@class="entry"]/img/@src'
```

The alternative would be to define custom `parse` and `parse_for_metadata` functions in each crawler where wanted information is stored in attribute values.
That would be cumbersome and verbose, hence this PR.