### PR TITLE
Cancel crawlers if they are idle after a certain timeout period

### DIFF
--- a/memorious/logic/context.py
+++ b/memorious/logic/context.py
@@ -83,6 +83,9 @@ class Context(object):
             Crawl.operation_end(self.crawler, self.run_id)
             shutil.rmtree(self.work_path)
 
+    def emit_heartbeat(self):
+        Crawl.heartbeat(self.crawler)
+
     def emit_warning(self, message, type=None, *args):
         if len(args):
             message = message % args

--- a/memorious/logic/crawler.py
+++ b/memorious/logic/crawler.py
@@ -93,6 +93,15 @@ class Crawler(object):
         Crawl.abort_all(self)
         self.queue.cancel()
 
+    @property
+    def should_timeout(self):
+        now = datetime.utcnow()
+        return self.last_run < now - timedelta(seconds=settings.CRAWLER_TIMEOUT) # noqa
+
+    def timeout(self):
+        log.warning("Crawler timed out: %s. Aggregator won't be run", self.name)  # noqa
+        self.cancel()
+
     def run(self, incremental=None, run_id=None):
         """Queue the execution of a particular crawler."""
         state = {

--- a/memorious/logic/manager.py
+++ b/memorious/logic/manager.py
@@ -34,6 +34,8 @@ class CrawlerManager(object):
                 continue
             if not crawler.check_due():
                 continue
+            if num_running >= settings.MAX_SCHEDULED:
+                continue
             log.info('[%s] due, queueing...', crawler.name)
             crawler.run()
             num_running += 1

--- a/memorious/model/crawl.py
+++ b/memorious/model/crawl.py
@@ -20,6 +20,10 @@ class Crawl(object):
         return unpack_datetime(last_run)
 
     @classmethod
+    def heartbeat(cls, crawler):
+        conn.set(make_key(crawler, "last_run"), pack_now())
+
+    @classmethod
     def op_count(cls, crawler, stage=None):
         """Total operations performed for this crawler"""
         if stage:

--- a/memorious/settings.py
+++ b/memorious/settings.py
@@ -45,7 +45,7 @@ THREADS = env.to_int('MEMORIOUS_THREADS', min(8, multiprocessing.cpu_count()))
 MAX_SCHEDULED = max(env.to_int('MEMORIOUS_MAX_SCHEDULED', THREADS), 20)
 
 # How many seconds to wait before timing out a crawler
-CRAWLER_TIMEOUT = env.to_int('MEMORIOUS_CRAWLER_TIMEOUT', 3600)
+CRAWLER_TIMEOUT = env.to_int('MEMORIOUS_CRAWLER_TIMEOUT', 3600 * 6)
 
 # Max number of tasks in a stage's task queue
 MAX_QUEUE_LENGTH = env.to_int('MEMORIOUS_MAX_QUEUE_LENGTH', 50000)

--- a/memorious/settings.py
+++ b/memorious/settings.py
@@ -42,7 +42,10 @@ SCHEDULER_INTERVAL = env.to_int('MEMORIOUS_SCHEDULER_INTERVAL', 60)
 THREADS = env.to_int('MEMORIOUS_THREADS', min(8, multiprocessing.cpu_count()))
 
 # Max scheduled tasks at the same time
-MAX_SCHEDULED = env.to_int('MEMORIOUS_MAX_SCHEDULED', THREADS)
+MAX_SCHEDULED = max(env.to_int('MEMORIOUS_MAX_SCHEDULED', THREADS), 20)
+
+# How many seconds to wait before timing out a crawler
+CRAWLER_TIMEOUT = env.to_int('MEMORIOUS_CRAWLER_TIMEOUT', 3600)
 
 # Max number of tasks in a stage's task queue
 MAX_QUEUE_LENGTH = env.to_int('MEMORIOUS_MAX_QUEUE_LENGTH', 50000)

--- a/memorious/worker.py
+++ b/memorious/worker.py
@@ -16,6 +16,9 @@ class MemoriousWorker(Worker):
                                         limit=1)
 
     def periodic(self):
+        for crawler in manager:
+            if crawler.should_timeout:
+                crawler.timeout()
         if self.scheduler.check() and not settings.DEBUG:
             log.info("Running scheduled crawlers ...")
             self.scheduler.update()

--- a/memorious/worker.py
+++ b/memorious/worker.py
@@ -14,11 +14,15 @@ class MemoriousWorker(Worker):
                                         unit=60,
                                         interval=settings.SCHEDULER_INTERVAL,
                                         limit=1)
+        self.hourly = get_rate_limit('hourly', unit=3600, interval=1, limit=1)
 
     def periodic(self):
-        for crawler in manager:
-            if crawler.should_timeout:
-                crawler.timeout()
+        if self.hourly.check():
+            self.hourly.update()
+            log.info("Running hourly tasks...")
+            for crawler in manager:
+                if crawler.should_timeout:
+                    crawler.timeout()
         if self.scheduler.check() and not settings.DEBUG:
             log.info("Running scheduled crawlers ...")
             self.scheduler.update()


### PR DESCRIPTION
Also introduces `emit_heartbeat` function on `context` object. The aim is to expose a way for the crawlers to indicate that they are alive. It should be particularly useful if the crawler has a huge for loop that take hours to run like many of our bigger crawlers. 