### PR TITLE
Parse and store metadata before emiting urls to fetch in parse operation

### DIFF
--- a/docs/buildingcrawler.md
+++ b/docs/buildingcrawler.md
@@ -225,7 +225,7 @@ An example `parse` configuration, which crawls links and stores only documents:
         mime_group: documents
       include_paths:
        - './/aside'
-       - './/article
+       - './/article'
       meta:
         creator: './/article/p[@class="author"]'
         title: './/h1'

--- a/memorious/operations/parse.py
+++ b/memorious/operations/parse.py
@@ -53,13 +53,14 @@ def parse_html(context, data, result):
                 if context.check_tag(tag):
                     continue
                 context.set_tag(tag, None)
-                data = {'url': url}
+                data['url'] = url
 
-                # Option to set the document title from the link text.
-                if context.get('link_title', False):
-                    data['title'] = collapse_spaces(element.text_content())
-                elif element.get('title'):
-                    data['title'] = collapse_spaces(element.get('title'))
+                if data.get('title') is None:
+                    # Option to set the document title from the link text.
+                    if context.get('link_title', False):
+                        data['title'] = collapse_spaces(element.text_content())
+                    elif element.get('title'):
+                        data['title'] = collapse_spaces(element.get('title'))
 
                 context.http.session.headers['Referer'] = url
                 context.emit(rule='fetch', data=data)
@@ -91,10 +92,9 @@ def parse_for_metadata(context, data, html):
 def parse(context, data):
     with context.http.rehash(data) as result:
         if result.html is not None:
-            parse_html(context, data, result)
-
             # Get extra metadata from the DOM
             parse_for_metadata(context, data, result.html)
+            parse_html(context, data, result)
 
         rules = context.params.get('store') or {'match_all': {}}
         if Rule.get_rule(rules).apply(result):

--- a/memorious/tests/test_operations.py
+++ b/memorious/tests/test_operations.py
@@ -1,5 +1,6 @@
 import os
 import json
+from unittest.mock import ANY
 
 import pytest
 
@@ -52,11 +53,13 @@ def test_parse(context, mocker):
 
     rules = {'pattern': 'https://httpbin.org/*'}
     context.params["store"] = rules
+    context.params["meta"] = {
+        "title": ".//h1",
+        "description": ".//p"
+    }
     parse(context, data)
     assert context.emit.call_count == 1
-    context.emit.assert_called_once_with(rule="fetch", data={
-        "url": "https://www.iana.org/domains/example"
-    })
+    context.emit.assert_called_once_with(rule="fetch", data=ANY)
 
     # cleanup tags
     conn = connect_redis()
@@ -65,6 +68,9 @@ def test_parse(context, mocker):
     context.http.result = None
     context.params["store"] = None
     parse(context, data)
+    assert data['url'] == 'https://www.iana.org/domains/example'
+    assert data['title'] == 'Example Domain'
+    assert data['description'].startswith('This domain is for')
     assert context.emit.call_count == 3, data
 
 


### PR DESCRIPTION
... to make sure metadata gets passed to the next stage along with the fetched content.

Here's a crawler config to test run the example in docs (https://memorious.readthedocs.io/en/latest/buildingcrawler.html#parse)

```yaml
name: glitch_parse
description: Parse metadata test
pipeline:
  init:
    method: seed
    params:
      urls: 
        - https://uncovered-calico-random.glitch.me/
    handle:
      pass: fetch
  fetch:
    method: fetch
    handle:
      pass: parse 
  parse:
    method: parse
    params:
      store:
        mime_group: documents
      include_paths:
        - './/article'
      meta:
        creator: './/article/p[@class="author"]'
        title: './/h1'
      meta_date:
        published_at: './/article/time'
        updated_at: './/article//span[@id="updated"]'
    handle:
        fetch: fetch
        store: store
  store:
    method: inspect
```