### PR TITLE
refactor: Add example config path for Docker

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -6,6 +6,7 @@ RUN pip3 install -q -e /crawlers
 COPY config /crawlers/config
 
 ENV MEMORIOUS_BASE_PATH=/data \
+    MEMORIOUS_CONFIG_PATH=/crawlers/config \
     MEMORIOUS_DEBUG=false \
     ARCHIVE_PATH=/data/archive \
     REDIS_URL=redis://redis:6379/0 \


### PR DESCRIPTION
In response to [Issue 124](https://github.com/alephdata/memorious/issues/124) in the example project, it took me (and probably others) some time to figure out that the `MEMORIOUS_CONFIG_PATH` is not set by default and will result in `memorious list` not returning any crawlers (or even hinting that the config might be non-existant/erroneous).

I propose a simple adding of the default path `/crawlers/config` to the Dockerfile in the example, which solves the issue.

An alternative might be adding a warning to the `README.md` stating that the `MEMORIOUS_CONFIG_PATH` is not set and has to be set by the user before the Docker container will work correctly.

If I missed something, please let me know =)