### PR TITLE
Option to run a multithreaded worker in sync mode.

### DIFF
--- a/memorious/cli.py
+++ b/memorious/cli.py
@@ -3,7 +3,7 @@ import logging
 from tabulate import tabulate
 
 from memorious import settings
-from memorious.core import manager, init_memorious, is_sync_mode
+from memorious.core import manager, init_memorious, is_sync_mode, conn
 from memorious.worker import get_worker
 
 log = logging.getLogger(__name__)
@@ -46,13 +46,17 @@ def run(crawler):
 @click.argument("crawler")
 @click.option("--threads", type=int, default=None)
 @click.option("--flush", is_flag=True, default=False)
-def sync_run(crawler, threads=None, flush=False):
+@click.option("--flushall", is_flag=True, default=False)
+def sync_run(crawler, threads=None, flush=False, flushall=False):
     """Run a specified crawler in synchronous mode."""
+    settings._sync_mode = True
     # Disable timeouts:
     settings.CRAWLER_TIMEOUT = settings.CRAWLER_TIMEOUT * 1000
     crawler = get_crawler(crawler)
     if flush:
         crawler.flush()
+    if flushall:
+        conn.flushall()
     crawler.run()
     if threads is not None:
         if settings.sls.REDIS_URL is None:

--- a/memorious/cli.py
+++ b/memorious/cli.py
@@ -44,19 +44,32 @@ def run(crawler):
 
 @cli.command("sync")
 @click.argument("crawler")
+@click.option("--threads", type=int, default=None)
 @click.option("--flush", is_flag=True, default=False)
-def sync_run(crawler, flush=False):
+def sync_run(crawler, threads=None, flush=False):
     """Run a specified crawler in synchronous mode."""
-    # Use fakeredis:
-    settings.sls.REDIS_URL = None
     # Disable timeouts:
     settings.CRAWLER_TIMEOUT = settings.CRAWLER_TIMEOUT * 1000
     crawler = get_crawler(crawler)
     if flush:
         crawler.flush()
     crawler.run()
-    worker = get_worker()
-    worker.sync()
+    if threads is not None:
+        if settings.sls.REDIS_URL is None:
+            log.warning(
+                "REDIS_URL not set. Can't run in multithreaded mode without Redis. Exiting."
+            )
+            return
+        if settings.DATASTORE_URI.startswith("sqlite:///"):
+            log.warning(
+                "Can't run in multithreaded mode with sqlite database. Exiting."
+            )
+            return
+        worker = get_worker(num_threads=threads)  # multithreaded worker
+        worker.run()
+    else:
+        worker = get_worker()
+        worker.sync()
 
 
 @cli.command()

--- a/memorious/core.py
+++ b/memorious/core.py
@@ -44,6 +44,8 @@ def load_tags():
 
 
 def is_sync_mode():
+    if hasattr(settings, "_sync_mode"):
+        return bool(settings._sync_mode)
     if settings.TESTING or settings.DEBUG:
         return True
     return sls.REDIS_URL is None

--- a/memorious/worker.py
+++ b/memorious/worker.py
@@ -45,6 +45,8 @@ class MemoriousWorker(Worker):
             state = task.context
             context = Context.from_state(state, stage)
             context.crawler.aggregate(context)
+            if is_sync_mode():
+                self.shutdown()
         self.timeout_expiration_check()
 
     def get_stages(self):


### PR DESCRIPTION
Multithreaded worker doesn't work with fakeredis or sqlite. So a Redis
server URI has to be set in REDIS_URL and a database server URI has to
be set in MEMORIOUS_DATASTORE_URI.

Calling syntax looks like: `memorious sync crawler_name --threads 4`