### PR TITLE
ENH aleph_emit passes keywords

### DIFF
--- a/memorious/operations/aleph.py
+++ b/memorious/operations/aleph.py
@@ -37,6 +37,7 @@ def aleph_emit(context, data):
         "modified_at": data.get("modified_at"),
         "published_at": data.get("published_at"),
         "headers": data.get("headers", {}),
+        "keywords": data.get("keywords", []),
     }
 
     languages = context.params.get("languages")


### PR DESCRIPTION
This PR enables for `keywords` to be transmitted via `aleph_emit`.