### PR TITLE
Fix weird filenames created during store stage

### DIFF
--- a/memorious/operations/store.py
+++ b/memorious/operations/store.py
@@ -25,7 +25,7 @@ def _get_directory_path(context):
 
 def _get_file_extension(file_name, mime_type):
     if file_name is not None:
-        _, extension = os.path.split(file_name)
+        _, extension = os.path.splitext(file_name)
         extension = extension.replace(".", "")
         if len(extension) > 1:
             return extension
@@ -51,7 +51,7 @@ def directory(context, data):
 
         path = _get_directory_path(context)
         file_name = data.get("file_name", result.file_name)
-        mime_type = normalize_mimetype(data.get("headers", {}).get("Content-Type"))
+        mime_type = normalize_mimetype(data.get("headers", {}).get("content-type"))
         extension = _get_file_extension(file_name, mime_type)
         file_name = file_name or "data"
         file_name = safe_filename(file_name, extension=extension)


### PR DESCRIPTION
Without this fix, because of using `os.path.split` instead of `os.path.splitext`, a crawled pdf file named

`WD-7-028-21-pdf-data.pdf`

ends up in the data folder like:

`WD_7_028_21_pdf_data.WD_7_028_21_pdf_datapdf`

which is probably not as it's supposed to be ;)