### PR TITLE
Proposal: Add possibility to use ENV vars in yaml config

### DIFF
--- a/memorious/logic/crawler.py
+++ b/memorious/logic/crawler.py
@@ -1,6 +1,5 @@
 import os
 import io
-import yaml
 import logging
 import re
 from datetime import timedelta
@@ -13,6 +12,7 @@ from memorious import settings
 from memorious.core import conn, tags
 from memorious.model import Crawl, Queue
 from memorious.logic.stage import CrawlerStage
+from memorious.util import load_yaml_with_env
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class Crawler(object):
         self.source_file = source_file
         with io.open(source_file, encoding="utf-8") as fh:
             self.config_yaml = fh.read()
-            self.config = yaml.safe_load(self.config_yaml)
+            self.config = load_yaml_with_env(self.config_yaml)
 
         self.name = os.path.basename(source_file)
         self.name = self.config.get("name", self.name)

--- a/memorious/util.py
+++ b/memorious/util.py
@@ -1,5 +1,8 @@
 import os
+import re
 from uuid import uuid4
+
+import yaml
 
 
 def random_filename(path=None):
@@ -9,3 +12,52 @@ def random_filename(path=None):
     if path is not None:
         filename = os.path.join(path, filename)
     return filename
+
+
+def load_yaml_with_env(data, tag="!ENV"):
+    """
+    https://medium.com/swlh/python-yaml-configuration-with-environment-variables-parsing-77930f4273ac
+
+    Load a yaml configuration file and resolve any environment variables
+    The environment variables must have !ENV before them and be in this format
+    to be parsed: ${VAR_NAME}.
+    E.g.:
+    database:
+        host: !ENV ${HOST}
+        port: !ENV ${PORT}
+    app:
+        log_path: !ENV '/var/${LOG_PATH}'
+        something_else: !ENV '${AWESOME_ENV_VAR}/var/${A_SECOND_AWESOME_VAR}'
+    :param str data: the yaml data itself as a stream
+    :param str tag: the tag to look for
+    :return: the dict configuration
+    :rtype: dict[str, T]
+    """
+    # pattern for global vars: look for ${word}
+    pattern = re.compile(r".*?\${(\w+)}.*?")
+    loader = yaml.SafeLoader
+
+    # the tag will be used to mark where to start searching for the pattern
+    # e.g. somekey: !ENV somestring${MYENVVAR}blah blah blah
+    loader.add_implicit_resolver(tag, pattern, None)
+
+    def constructor_env_variables(loader, node):
+        """
+        Extracts the environment variable from the node's value
+        :param yaml.Loader loader: the yaml loader
+        :param node: the current node in the yaml
+        :return: the parsed string that contains the value of the environment
+        variable
+        """
+        value = loader.construct_scalar(node)
+        match = pattern.findall(value)  # to find all env variables in line
+        if match:
+            full_value = value
+            for g in match:
+                full_value = full_value.replace(f"${{{g}}}", os.environ.get(g, ""))
+            return full_value
+        return value
+
+    loader.add_constructor(tag, constructor_env_variables)
+
+    return yaml.load(data, Loader=loader)


### PR DESCRIPTION
Hey, 

i find it very useful to use ENV vars in yaml config, to use crawlers via the cli like:

config
```yaml
...
params:
  startdate: !ENV ${STARTDATE}
...
```
and then execute:

`STARTDATE=2021-05-27 memorious run my_crawler`

Therefore the yaml parsing for the config file needs to be modified, I found a solution here: https://medium.com/swlh/python-yaml-configuration-with-environment-variables-parsing-77930f4273ac which I added into `util.py`

What do you think about this idea?