### PR TITLE
Document upload: fix aleph validation errors and make sure all metadata is stored in cache (not only document id)

### DIFF
--- a/memorious/operations/aleph.py
+++ b/memorious/operations/aleph.py
@@ -13,9 +13,9 @@ from memorious.core import get_rate_limit  # type: ignore
 def _create_document_metadata(context, data) -> dict:
     meta = {}
     languages = context.params.get("languages")
-    meta["languages"] = data.get("languages", languages)
+    meta["languages"] = ensure_list(data.get("languages", languages))
     countries = context.params.get("countries")
-    meta["countries"] = data.get("countries", countries)
+    meta["countries"] = ensure_list(data.get("countries", countries))
     mime_type = context.params.get("mime_type")
     meta["mime_type"] = data.get("mime_type", mime_type)
     return meta

--- a/memorious/operations/aleph.py
+++ b/memorious/operations/aleph.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 from pprint import pprint  # noqa
-from banal import clean_dict  # type: ignore
 
-from servicelayer.cache import make_key  # type: ignore
 from alephclient import settings
 from alephclient.api import AlephAPI
-from alephclient.util import backoff
 from alephclient.errors import AlephException
+from alephclient.util import backoff
+from banal import clean_dict, ensure_dict, ensure_list  # type: ignore
+from servicelayer.cache import make_key  # type: ignore
+
 from memorious.core import get_rate_limit  # type: ignore
 
 
@@ -36,8 +37,8 @@ def _create_meta_object(context, data) -> dict:
         "retrieved_at": data.get("retrieved_at"),
         "modified_at": data.get("modified_at"),
         "published_at": data.get("published_at"),
-        "headers": data.get("headers", {}),
-        "keywords": data.get("keywords", []),
+        "headers": ensure_dict(data.get("headers")),
+        "keywords": ensure_list(data.get("keywords")),
     }
 
     if data.get("aleph_folder_id"):
@@ -59,10 +60,13 @@ def aleph_emit_document(context, data):
     source_url = data.get("source_url", data.get("url"))
     foreign_id = data.get("foreign_id", data.get("request_id", source_url))
     # Fetch document id from cache
-    document_id = context.get_tag(make_key(collection_id, foreign_id, content_hash))
-    if document_id:
+    document = context.get_tag(make_key(collection_id, foreign_id, content_hash))
+    if document:
         context.log.info("Skip aleph upload: %s", foreign_id)
-        data["aleph_id"] = document_id
+        context.log.info("Skip aleph upload: %s", foreign_id)
+        data["aleph_id"] = document["id"]
+        data["aleph_document"] = document
+        data["aleph_collection_id"] = collection_id
         context.emit(data=data, optional=True)
         return
 
@@ -85,9 +89,8 @@ def aleph_emit_document(context, data):
                 document_id = res.get("id")
                 context.log.info("Aleph document ID: %s", document_id)
                 # Save the document id in cache for future use
-                context.set_tag(
-                    make_key(collection_id, foreign_id, content_hash), document_id
-                )
+                meta["id"] = document_id
+                context.set_tag(make_key(collection_id, foreign_id, content_hash), meta)
                 data["aleph_id"] = document_id
                 data["aleph_document"] = meta
                 data["aleph_collection_id"] = collection_id

--- a/memorious/operations/aleph.py
+++ b/memorious/operations/aleph.py
@@ -61,7 +61,7 @@ def aleph_emit_document(context, data):
     foreign_id = data.get("foreign_id", data.get("request_id", source_url))
     # Fetch document id from cache
     document = context.get_tag(make_key(collection_id, foreign_id, content_hash))
-    if document:
+    if isinstance(document, dict):
         context.log.info("Skip aleph upload: %s", foreign_id)
         data["aleph_id"] = document["id"]
         data["aleph_document"] = document

--- a/memorious/operations/aleph.py
+++ b/memorious/operations/aleph.py
@@ -63,7 +63,6 @@ def aleph_emit_document(context, data):
     document = context.get_tag(make_key(collection_id, foreign_id, content_hash))
     if document:
         context.log.info("Skip aleph upload: %s", foreign_id)
-        context.log.info("Skip aleph upload: %s", foreign_id)
         data["aleph_id"] = document["id"]
         data["aleph_document"] = document
         data["aleph_collection_id"] = collection_id


### PR DESCRIPTION
this PR provides 2 small improvements handling documents metadata

1)  https://github.com/alephdata/memorious/commit/6b5ea186048577864fabed9024cc11ba9e83904b
a bugfix for uploading to aleph: if `countries` and `languages` are not listish (e.g. `None` instead) the api raises a validation error "ERROR [countries]: None is not of type 'array' [aleph.views.util]" this is fixed in ensuring always a list for these fields

2) https://github.com/alephdata/memorious/commit/7c23061e6398f8e893ac11b5e5756b426e0b5742
a fix/improvement for handling the data dict for documents for `aleph_emit_document`: the whole metadata dict should be stored in the datastore, not only the document id. If there is a stage after the document upload that does something with the passed-through data dict, it breaks if the document was already (previously) uploaded to aleph, as the `aleph_emit_document` stage then only emits the document id, not the original data dict itself. 