### PR TITLE
Parse: Allow explizit `a` xpaths

### DIFF
--- a/memorious/operations/parse.py
+++ b/memorious/operations/parse.py
@@ -10,6 +10,7 @@ from memorious.helpers.dates import iso_date
 
 log = logging.getLogger(__name__)
 URL_TAGS = [
+    (".", "href"),
     (".//a", "href"),
     (".//img", "src"),
     (".//link", "href"),


### PR DESCRIPTION
a one-liner with huge effect ;) for now, i could not encounter any negative side-effects about this in my scrapers.

for use in the `parse` stage when dealing with the `include_paths` param, it can be very useful to be able to reference exact xpaths to specific links (a tags) on a page, i.e. a tag with a specific css class for pagination. 

consider this markup:

```html
<div class="pagination">
<a class="previous" href="/1">previous</a>
<a class="next" href="/2">next</a>
</div>
```
in the current implementation, we cannot directly specify only the "next" page link, as in the xpath we would need to set `.//div[@class="pagination"]` so that memorious finds all `a` children 

with this improvement, the "next" link can be directly specified via xpath `.//a[@class="next"]`