### PR TITLE
Fix issue when dateparser.parse returns None

### DIFF
--- a/memorious/logic/http.py
+++ b/memorious/logic/http.py
@@ -253,6 +253,9 @@ class ContextHttpResponse(object):
         if last_modified_header is not None:
             # Tue, 15 Nov 1994 12:45:26 GMT
             last_modified = parse_date(last_modified_header)
+            if last_modified is None:
+                return None
+
             if last_modified < now + timedelta(seconds=30):
                 return last_modified.strftime("%Y-%m-%dT%H:%M:%S%z")
         return None

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="memorious",
-    version="2.5.0",
+    version="2.5.1",
     description="A minimalistic, recursive web crawling library for Python.",
     long_description="",
     classifiers=[


### PR DESCRIPTION
It is possible for dateparser.parse method to return None and when this happens we are comparing a None against a datetime raising an exception.

This is only possible right now because there is a bug (https://github.com/scrapinghub/dateparser/issues/1116) in dateparser  that is not recognizing "Mon" as "Monday".