### PR TITLE
Redirect index page to new documentation site

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,7 @@
+.. meta::
+   :http-equiv=Refresh: 15; url='https://alephdata.github.io/memorious/'
+
+The Memorious documentation has moved
+=====================================
+
+You will be redirected automatically in 15 seconds. If you are not redirected, follow this link: `alephdata.github.io/memorious <https://alephdata.github.io/memorious>`_.


### PR DESCRIPTION
Read the Docs doesn't allow setting up a proper redirect for the index page, so we need to create a fake index page with a meta redirect tag.