### PR TITLE
Fix failing test as the source has changed

### DIFF
--- a/memorious/tests/test_operations.py
+++ b/memorious/tests/test_operations.py
@@ -78,7 +78,6 @@ def test_parse_ftm(context, mocker):
     context.params["schema"] = "Article"
     context.params["properties"] = {
         "title": './/meta[@property="og:title"]/@content',
-        "author": './/meta[@name="author"]/@content',
         "publishedAt": './/*[@class="date"]/text()',
         "description": './/meta[@property="og:description"]/@content',
     }
@@ -88,7 +87,6 @@ def test_parse_ftm(context, mocker):
     props = data["properties"]
 
     assert "Riviera Maya Gang Members Sentenced in Romania" in props["title"]
-    assert "Attila Biro" in props["author"]
     assert props["description"][0].startswith("A Bucharest court")
 
 


### PR DESCRIPTION
This test relies on a web page that seems to have changed (the author meta tag isn't part of the page source anymore). While the author is still mentioned on the page, the XPath selector would be more complex and would probably fail again soon anyways. As it's not relevant for this particular test, I've simply removed this property.

A more reliable long-term solution would be to store the source of web pages that the tests rely on as part of this repository and then mock the HTTP requests.